### PR TITLE
Fix bad pattern matching (#4)

### DIFF
--- a/lib/shorty/controllers/.tool-versions
+++ b/lib/shorty/controllers/.tool-versions
@@ -1,0 +1,2 @@
+erlang 23.1.1
+elixir 1.11.2

--- a/lib/shorty/controllers/domain.ex
+++ b/lib/shorty/controllers/domain.ex
@@ -13,8 +13,10 @@ defmodule Shorty.Controllers.Domain do
           shorten_url: build_shorten_url(domain.short_tag)
         })
 
-      {:error, %Ecto.Changeset{errors: [url: {_, _}]}} ->
-        respond(conn, 422, %{error: "unprocessable_entity", message: "The URL is not valid"})
+      {:error, %Ecto.Changeset{errors: errors}} ->
+        error_details = format_changeset_errors(errors)
+
+        respond(conn, 422, %{error: "unprocessable_entity", details: error_details})
     end
   end
 
@@ -59,5 +61,11 @@ defmodule Shorty.Controllers.Domain do
     else
       "#{scheme}://#{domain_name}/#{short_tag}"
     end
+  end
+
+  defp format_changeset_errors(errors) do
+    errors
+    |> Enum.reduce([], fn {key, value}, acc -> acc ++ ["#{key}": elem(value, 0)] end)
+    |> Enum.into(%{})
   end
 end

--- a/test/shorty/controllers/domain_test.exs
+++ b/test/shorty/controllers/domain_test.exs
@@ -61,7 +61,7 @@ defmodule Shorty.Controllers.DomainTest do
     assert {:ok, body} = Jason.decode(conn.resp_body)
 
     assert body["error"] == "unprocessable_entity"
-    assert body["message"] == "The URL is not valid"
+    assert body["details"]["url"] == "can't be blank"
   end
 
   test "create: returns an unprocessable_entity when the url isn't valid" do
@@ -78,7 +78,7 @@ defmodule Shorty.Controllers.DomainTest do
     assert {:ok, body} = Jason.decode(conn.resp_body)
 
     assert body["error"] == "unprocessable_entity"
-    assert body["message"] == "The URL is not valid"
+    assert body["details"]["url"] == "is missing a scheme (e.g. https)"
   end
 
   test "show: redirect the user when everything is fine" do


### PR DESCRIPTION
This pull request fix an "unsafe" pattern matching, based on a keyword list. Instead, we take all the errors contained in a changeset and format them into a map ready to be JSON parsed (without useless information).

I also add the `.tool-versions` file. It seems that I forgot to add it when creating this project. 🤷‍♂️ 