### PR TITLE
Remove business logic from domain's controller

### DIFF
--- a/lib/shorty/controllers/domain.ex
+++ b/lib/shorty/controllers/domain.ex
@@ -2,7 +2,6 @@ defmodule Shorty.Controllers.Domain do
   import Shorty.Controller
 
   def create(conn, params) do
-    # TODO(arnaud): Isolate business logic inside a workflow with input validation.
     original_url = params["url"] || ""
 
     case find_or_create_domain(original_url) do
@@ -21,7 +20,6 @@ defmodule Shorty.Controllers.Domain do
   end
 
   def show(conn, params) do
-    # TODO(arnaud): Isolate business logic inside a workflow with input validation.
     short_tag = params["short_tag"] || ""
 
     case Shorty.Queries.Domain.by_short_tag(short_tag) do


### PR DESCRIPTION
This commit removes the TODO annotations from the controller.

I will not fix the issue raised here https://github.com/arnaudmorisset/shorty/issues/3

This application is not intended to grow and there is no need to maintain it. If we take in account the scope of this application, trying to apply a CQRS-like pattern is over-engineering (even a simplified one),